### PR TITLE
Add totalCountTableReducer and modify song table layout.

### DIFF
--- a/music_schema.ddl
+++ b/music_schema.ddl
@@ -16,13 +16,16 @@ CREATE TABLE songs WITH DESCRIPTION 'Songs available for playing'
 ROW KEY FORMAT HASH PREFIXED(4)
 WITH LOCALITY GROUP default
   WITH DESCRIPTION 'Main locality group' (
-  MAXVERSIONS = INFINITY,
+  MAXVERSIONS = 1,
   TTL = FOREVER,
   INMEMORY = false,
   COMPRESSED WITH NONE,
   FAMILY info WITH DESCRIPTION 'Information about a song' (
     metadata CLASS org.kiji.examples.music.SongMetadata WITH DESCRIPTION 'Song metadata',
+  ),
+  FAMILY derived WITH DESCRIPTION 'Data derived from user interactions' (
     top_30_next_songs CLASS org.kiji.examples.music.NextSongProbability
-      WITH DESCRIPTION 'Probabilities of a song being the next song to be played'
+       WITH DESCRIPTION 'Probabilities of a song being the next song to be played'
+    number_of_plays "long" WITH DESCRIPTION 'Count of the number of plays.'
   )
 );

--- a/src/main/java/org/kiji/music/reduce/TotalCountTableReducer.java
+++ b/src/main/java/org/kiji/music/reduce/TotalCountTableReducer.java
@@ -1,0 +1,57 @@
+/**
+ * (c) Copyright 2013 WibiData, Inc.
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiji.music.reduce;
+
+import java.io.IOException;
+
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+
+import org.kiji.common.flags.Flag;
+import org.kiji.mapreduce.KijiTableContext;
+import org.kiji.mapreduce.KijiTableReducer;
+
+/**
+ * A reducer that will sum the values associated with a key and write that sum
+ * to a column specified via command line flags.
+ */
+public class TotalCountTableReducer extends KijiTableReducer<Text, LongWritable> {
+  // For our music project, we are writing to column family "derived".
+  @Flag(name="column-family", usage="Specify the column family to write to.")
+  public String mColumnFamily;
+
+  // For our music project, we are writing to column qualifier "number_of_plays".
+  @Flag(name="column-qualifier", usage="Specify the column qualifier to write to.")
+  public String mColumnQualifier;
+
+  /** {@inheritDoc} */
+  @Override
+  protected void reduce(Text key, Iterable<LongWritable> values, KijiTableContext context)
+      throws IOException {
+    // Initialize sum to zero.
+    long sum = 0L;
+    // Add up all the values.
+    for (LongWritable value : values) {
+      sum += value.get();
+    }
+    // Write out result for this song
+    context.put(context.getEntityId(key.toString()), mColumnFamily, mColumnQualifier, values);
+  }
+}


### PR DESCRIPTION
Modify table layout to include a column for the total count, as well as only keep one version in the default locality group of the song table.

Also adds a reducer that writes the total plays to a command line specified column.
