### PR TITLE
Add explicit compile dependency to HBase.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase</artifactId>
+      <version>${hbase.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
       <version>1.1</version>


### PR DESCRIPTION
Not doing so leads to HBase classes being not found by the tasks.
