### PR TITLE
Add table import descriptor for using generic bulk importer

### DIFF
--- a/import/song-plays-import-descriptor.json
+++ b/import/song-plays-import-descriptor.json
@@ -1,0 +1,14 @@
+{
+  name : "users",
+  families : [ {
+    name : "info",
+    columns : [ {
+      name : "track_plays",
+      source : "song_id"
+    } ]
+  } ],
+  entityIdSource : "user_id",
+  overrideTimestampSource : "play_time",
+  version : "import-1.0"
+}
+


### PR DESCRIPTION
This basically does the work of https://github.com/kijiproject/kiji-music/blob/d820f4e528124e636bba258ce44fb9f7cffe318c/src/main/java/org/kiji/examples/music/bulkimport/TrackPlaysBulkImporter.java

If @jhlch is curious.
