### PR TITLE
Improves the default KVStore implementation in NextSongRecommender.

### DIFF
--- a/src/main/java/org/kiji/examples/music/produce/NextSongRecommender.java
+++ b/src/main/java/org/kiji/examples/music/produce/NextSongRecommender.java
@@ -32,9 +32,12 @@ import org.kiji.mapreduce.kvstore.KeyValueStore;
 import org.kiji.mapreduce.kvstore.KeyValueStoreClient;
 import org.kiji.mapreduce.kvstore.KeyValueStoreReader;
 import org.kiji.mapreduce.kvstore.RequiredStores;
+import org.kiji.mapreduce.kvstore.lib.KijiTableKeyValueStore;
 import org.kiji.mapreduce.kvstore.lib.UnconfiguredKeyValueStore;
 import org.kiji.schema.KijiDataRequest;
 import org.kiji.schema.KijiRowData;
+import org.kiji.schema.KijiURI;
+import org.kiji.schema.KijiURIException;
 
 /**
  * Producer generating recommendations for the next songs each user might like.
@@ -79,7 +82,7 @@ public class NextSongRecommender extends KijiProducer implements KeyValueStoreCl
   /** {@inheritDoc} */
   @Override
   public Map<String, KeyValueStore<?, ?>> getRequiredStores() {
-    /** KijiTableKeyValueStore.Builder kvStoreBuilder = KijiTableKeyValueStore.builder();
+    KijiTableKeyValueStore.Builder kvStoreBuilder = KijiTableKeyValueStore.builder();
     // Our default implementation will use the default kiji instance, and a table named songs.
     KijiURI tableURI;
     try { //TODO: figure out a reasonable default
@@ -87,9 +90,8 @@ public class NextSongRecommender extends KijiProducer implements KeyValueStoreCl
     } catch (KijiURIException ex) {
       throw new RuntimeException(ex);
     }
-    kvStoreBuilder.withColumn("info", "top_next_songs").withTable(tableURI); */
-    // return RequiredStores.just("nextPlayed", kvStoreBuilder.build());
-    return RequiredStores.just("nextPlayed", UnconfiguredKeyValueStore.builder().build());
+    kvStoreBuilder.withColumn("info", "top_next_songs").withTable(tableURI);
+     return RequiredStores.just("nextPlayed", kvStoreBuilder.build());
   }
 
   /**


### PR DESCRIPTION
The change to the default behavior of KijiURI builders allows us to define a useful default implementation of the KVstore to use in our recommendations producer. I think the KijiURI Exceptions are also unchecked now, which means we can remove the ugly try/catch. Unfortunately, maven is flailing around with fake errors for me locally:

[ERROR] /home/juliet/src/kiji/kiji-music/src/main/java/org/kiji/examples/music/gather/SequentialPlayCounter.java:[84,12] cannot find symbol
[ERROR] symbol  : method newColumnsDef()
[ERROR] location: class org.kiji.schema.KijiDataRequestBuilder

Instead of fighting with maven (for more than an hour) over something I know should work, I'm moving on, and hoping you can build this correctly. 
